### PR TITLE
Bugs fix: Home layout doesn't display correctly on Android device

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,11 +1,3 @@
-import CategoryList from "@/components/home/CategoryList"
-import Header from "@/components/home/Header"
-import HorizontalProductList from "@/components/home/HorizontalProductList"
-import OfferSection from "@/components/home/OfferSection"
-import SearchBar from "@/components/home/SearchBar"
-import SeeAllButton from "@/components/home/SeeAllButton"
-import VerticalProductList from "@/components/home/VerticalProductList"
-import { products } from "@/components/ProductData"
 import React, { useRef, useState } from "react"
 import {
   Animated,
@@ -16,6 +8,15 @@ import {
   Text,
   View,
 } from "react-native"
+
+import CategoryList from "@/components/home/CategoryList"
+import Header from "@/components/home/Header"
+import HorizontalProductList from "@/components/home/HorizontalProductList"
+import OfferSection from "@/components/home/OfferSection"
+import SearchBar from "@/components/home/SearchBar"
+import SeeAllButton from "@/components/home/SeeAllButton"
+import VerticalProductList from "@/components/home/VerticalProductList"
+import { products } from "@/components/ProductData"
 
 const HomeScreen = () => {
   const scrollOffsetY = useRef(new Animated.Value(0)).current
@@ -52,7 +53,7 @@ const HomeScreen = () => {
           )}
         >
           <SearchBar />
-          
+
           <CategoryList onCategorySelect={handleCategorySelect} />
 
           <HorizontalProductList products={products} />

--- a/components/home/Header.tsx
+++ b/components/home/Header.tsx
@@ -7,7 +7,7 @@ interface HeaderProps {
 
 const Header = ({ headerValue, children }: HeaderProps) => {
   const max_header_height = 150
-  const min_header_height = 0
+  const min_header_height = Platform.OS === "ios" ? 0 : (StatusBar.currentHeight || 0)
   const scroll_distance = max_header_height - min_header_height
 
   const animatedHeaderHeight = headerValue.interpolate({
@@ -37,7 +37,9 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: "column",
     paddingHorizontal: 30,
-    paddingVertical: 20,
+    marginTop: Platform.OS === "ios" ? 0 : (StatusBar.currentHeight || 0) + 20,
+    paddingBottom: 20,
+    paddingTop: Platform.OS === "ios" ? 20 : 0,
     backgroundColor: "#74a671",
     height: 150,
     zIndex: 1,

--- a/components/home/SearchBar.tsx
+++ b/components/home/SearchBar.tsx
@@ -30,8 +30,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     backgroundColor: "#F6F6F6",
-    padding: 10,
     height: 50,
+    paddingHorizontal: 10,
     borderRadius: 100,
     marginBottom: 20,
   },
@@ -40,5 +40,6 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 17,
     color: "#5D5D5D",
+    lineHeight: 40,
   },
 })

--- a/components/home/SearchBar.tsx
+++ b/components/home/SearchBar.tsx
@@ -40,6 +40,5 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 17,
     color: "#5D5D5D",
-    lineHeight: 40,
   },
 })


### PR DESCRIPTION
**Fix some following issues:**
- The home container can scroll over the Android status bar.
- The search input field is hidden by padding on Android

**Before:**
<img width="728" alt="image" src="https://github.com/user-attachments/assets/2a6b9901-78a4-48d3-bb24-acefba9e917c" />

**After fix these issues:**
<img width="708" alt="image" src="https://github.com/user-attachments/assets/5c54a3cc-b27e-4c5f-b488-5d656f804a95" />