### PR TITLE
Bug fix: Home's container doesn't display correctly

### DIFF
--- a/components/home/Header.tsx
+++ b/components/home/Header.tsx
@@ -1,4 +1,11 @@
-import { Animated, Platform, StatusBar, StyleSheet, Text, View } from "react-native";
+import {
+  Animated,
+  Platform,
+  StatusBar,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native"
 
 interface HeaderProps {
   headerValue: Animated.Value
@@ -7,7 +14,8 @@ interface HeaderProps {
 
 const Header = ({ headerValue, children }: HeaderProps) => {
   const max_header_height = 150
-  const min_header_height = 0
+  const min_header_height =
+    Platform.OS === "android" ? StatusBar.currentHeight || 0 : 0
   const scroll_distance = max_header_height - min_header_height
 
   const animatedHeaderHeight = headerValue.interpolate({
@@ -24,9 +32,7 @@ const Header = ({ headerValue, children }: HeaderProps) => {
         },
       ]}
     >
-      <View style={styles.header}>
-        {children}
-      </View>
+      <View style={styles.header}>{children}</View>
     </Animated.View>
   )
 }
@@ -42,5 +48,4 @@ const styles = StyleSheet.create({
     height: 150,
     zIndex: 1,
   },
-  
 })


### PR DESCRIPTION
Fix the home's container can scroll over the status bar on Android devices.

**Before**
<img width="359" alt="image" src="https://github.com/user-attachments/assets/5ff6e750-04ef-4e17-ab6e-8fea9b883284" />

**After**
<img width="354" alt="image" src="https://github.com/user-attachments/assets/0589bd6d-8d7e-49f4-8109-ec44e99f8aef" />
